### PR TITLE
Stg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,10 @@ const colorMap = {
 
 # Changelog
 
+## 2.3.1
+
+-   Fixed: Homepage alternate images are now being used in the correct spots.
+
 ## 2.3.0
 
 -   Added: Common post patterns have been registered with the `patterns` directory

--- a/wp-content/themes/together-were-more/style.css
+++ b/wp-content/themes/together-were-more/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/choctaw-nation/together-were-more
 Author: Choctaw Nation of Oklahoma
 Author URI: https://www.choctawnation.com/
 Description: A starter theme for Choctaw Wordpress Sites.
-Version: 2.3.0
+Version: 2.3.1
 Requires at least: 6.7.0
 Tested up to: 6.8.2
 Requires PHP: 8.2

--- a/wp-content/themes/together-were-more/template-parts/card-post-preview.php
+++ b/wp-content/themes/together-were-more/template-parts/card-post-preview.php
@@ -5,17 +5,29 @@
  * @package ChoctawNation
  */
 
+$alternate_image_id = mp_get_field( 'homepage_current_feature_image', get_the_ID() );
+$image_size         = 'profile-preview-card';
+$image_args         = array(
+	'class'   => 'w-100 object-fit-cover',
+	'loading' => 'lazy',
+);
 ?>
 <div class="post-preview-card d-flex flex-column h-100 position-relative">
 	<figure class="post-preview-card__cover mb-0 ratio ratio-16x9">
 		<?php
-		the_post_thumbnail(
-			'profile-preview-card',
-			array(
-				'class'   => 'w-100 object-fit-cover',
-				'loading' => 'lazy',
-			)
-		);
+		if ( $alternate_image_id ) {
+			echo wp_get_attachment_image(
+				$alternate_image_id,
+				$image_size,
+				false,
+				$image_args
+			);
+		} else {
+			the_post_thumbnail(
+				$image_size,
+				$image_args
+			);
+		}
 		?>
 		<div class="post-preview-card__overlay bg-dark bg-opacity-50 w-100 h-100 z-1"></div>
 		<figcaption class="h-auto text-white position-relative z-2 mx-5 mb-3">
@@ -29,7 +41,15 @@
 	</figure>
 	<div class="post-preview-card__body text-white p-5 pt-3 d-flex flex-column h-100 z-2">
 		<p class="mb-5">
-			<?php the_field( 'archive_content' ); ?>
+			<?php
+			if ( ! empty( $homepage_alt_description ) ) {
+				echo $homepage_alt_description;
+			} elseif ( empty( get_the_excerpt( $featured_profile_id ) ) ) {
+				echo get_field( 'archive_content', $featured_profile_id );
+			} else {
+				echo get_the_excerpt( $featured_profile_id );
+			}
+			?>
 		</p>
 		<?php
 		$category       = get_the_category();

--- a/wp-content/themes/together-were-more/template-parts/home/section-current-feature.php
+++ b/wp-content/themes/together-were-more/template-parts/home/section-current-feature.php
@@ -10,21 +10,17 @@ if ( ! $featured_profile ) {
 	return;
 }
 wp_enqueue_style( 'current-feature' );
-$featured_profile_id            = is_int( $featured_profile ) ? $featured_profile : $featured_profile->ID;
-$bg_image                       = get_template_directory_uri() . '/src/assets/white-texture.jpeg';
-$homepage_current_feature_image = mp_get_field( 'homepage_current_feature_image', $featured_profile_id );
-if ( ! $homepage_current_feature_image ) {
-	$homepage_current_feature_image = get_post_thumbnail_id( $featured_profile_id );
-}
-$srcset_str  = wp_get_attachment_image_srcset( $homepage_current_feature_image, 'full' );
-$srcset_by_w = explode( ',', $srcset_str );
-$srcset_by_h = array_map(
+$featured_profile_id = is_int( $featured_profile ) ? $featured_profile : $featured_profile->ID;
+$bg_image            = get_template_directory_uri() . '/src/assets/white-texture.jpeg';
+$srcset_str          = wp_get_attachment_image_srcset( get_post_thumbnail_id( $featured_profile_id ), 'full' );
+$srcset_by_w         = explode( ',', $srcset_str );
+$srcset_by_h         = array_map(
 	function ( $srcset ) {
 		return substr( $srcset, 0, -1 ) . 'h';
 	},
 	$srcset_by_w
 );
-$image_args  = array(
+$image_args          = array(
 	'class'   => 'w-100 h-100 object-fit-cover',
 	'loading' => 'lazy',
 	'srcset'  => implode( ', ', $srcset_by_h ),
@@ -35,21 +31,10 @@ $image_args  = array(
 	<div class="row row-cols-1 row-cols-lg-2 align-items-stretch justify-content-between">
 		<div class="col-lg-5 gx-0 featured__image overflow-hidden">
 			<?php
-			if ( $homepage_current_feature_image ) {
-				echo wp_get_attachment_image(
-					$homepage_current_feature_image,
-					'full',
-					false,
-					$image_args
-				);
-			} else {
-				echo get_the_post_thumbnail(
-					$featured_profile_id,
-					'full',
-					$image_args
-				);
-
-			}
+			the_post_thumbnail(
+				'full',
+				$image_args
+			)
 			?>
 		</div>
 		<div class="col py-5 px-4 d-flex flex-column justify-content-center align-items-center text-center text-lg-start">


### PR DESCRIPTION
This pull request updates the theme to version 2.3.1 and introduces fixes to ensure alternate images and descriptions are correctly displayed in specific sections of the site. The changes primarily focus on improving image handling and content display logic in template files.

### Version Update:
* [`wp-content/themes/together-were-more/style.css`](diffhunk://#diff-ef2715c45b3f13842397e74d50d2d2ccf86daebb2c0fc6ad25789ffd76799927L7-R7): Updated the theme version from `2.3.0` to `2.3.1`.

### Fixes for Image Handling:
* [`wp-content/themes/together-were-more/template-parts/card-post-preview.php`](diffhunk://#diff-06b6f87d7a6ef4ae2ca2348f12692251e6d11f4af3e2c9dba2faf7f16ef8ac88R8-R30): Added logic to use alternate images (`homepage_current_feature_image`) for post previews when available, falling back to the default post thumbnail otherwise.
* [`wp-content/themes/together-were-more/template-parts/home/section-current-feature.php`](diffhunk://#diff-ed06ff64e55bae5329875d9171f2f7570b0f1d5589f49063ff88fc06e00d7c7eL15-R15): Removed alternate image handling logic (`homepage_current_feature_image`) for the current feature section and simplified it to always use the post thumbnail. [[1]](diffhunk://#diff-ed06ff64e55bae5329875d9171f2f7570b0f1d5589f49063ff88fc06e00d7c7eL15-R15) [[2]](diffhunk://#diff-ed06ff64e55bae5329875d9171f2f7570b0f1d5589f49063ff88fc06e00d7c7eL38-R37)

### Fixes for Content Display:
* [`wp-content/themes/together-were-more/template-parts/card-post-preview.php`](diffhunk://#diff-06b6f87d7a6ef4ae2ca2348f12692251e6d11f4af3e2c9dba2faf7f16ef8ac88L32-R52): Enhanced content display logic to prioritize `homepage_alt_description`, followed by the excerpt or archive content of the featured profile.

### Changelog Update:
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R16-R19): Added a changelog entry for version 2.3.1, noting the fixes for alternate images.