### PR TITLE
fix homepage img alignment issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ const colorMap = {
 ## 2.4.5 - [September 29, 2025]
 
 - Fixed: Homepage hero image is no longer positioned.
+- Fixed: Category spotlight (penultimate homepage section) pulls the posts' featured images again. (regression introduced by KJ and now he fixed it.)
 
 ## 2.4.4
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,11 @@ const colorMap = {
 
 # Changelog
 
-## 2.4.4 - [September 29, 2025]
+## 2.4.5 - [September 29, 2025]
+
+- Fixed: Homepage hero image is no longer positioned.
+
+## 2.4.4
 
 - Fixed: Current Feature section uses the meta photo from the profile and falls back to the post's featured image when not set.
 - Chore: Update packages

--- a/wp-content/themes/together-were-more/src/styles/pages/home.scss
+++ b/wp-content/themes/together-were-more/src/styles/pages/home.scss
@@ -9,20 +9,6 @@
 		height: calc(100vh - var(--header-height, 93px));
 	}
 
-	img {
-		--left-align: 30%;
-
-		object-position: var(--left-align) center;
-
-		@include m.media-breakpoint-up(sm) {
-			--left-align: 20%;
-		}
-
-		@include m.media-breakpoint-up(md) {
-			--left-align: 15%;
-		}
-	}
-
 	#scroll-down-icon {
 		--size: 40px;
 

--- a/wp-content/themes/together-were-more/style.css
+++ b/wp-content/themes/together-were-more/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/choctaw-nation/together-were-more
 Author: Choctaw Nation of Oklahoma
 Author URI: https://www.choctawnation.com/
 Description: A starter theme for Choctaw Wordpress Sites.
-Version: 2.4.4
+Version: 2.4.5
 Requires at least: 6.7.0
 Tested up to: 6.8.2
 Requires PHP: 8.2

--- a/wp-content/themes/together-were-more/template-parts/card-post-preview.php
+++ b/wp-content/themes/together-were-more/template-parts/card-post-preview.php
@@ -5,9 +5,8 @@
  * @package ChoctawNation
  */
 
-$alternate_image_id = mp_get_field( 'homepage_current_feature_image' );
-$image_size         = 'profile-preview-card';
-$image_args         = array(
+$image_size = 'profile-preview-card';
+$image_args = array(
 	'class'   => 'w-100 object-fit-cover',
 	'loading' => 'lazy',
 );
@@ -15,19 +14,10 @@ $image_args         = array(
 <div class="post-preview-card d-flex flex-column h-100 position-relative">
 	<figure class="post-preview-card__cover mb-0 ratio ratio-16x9">
 		<?php
-		if ( $alternate_image_id ) {
-			echo wp_get_attachment_image(
-				$alternate_image_id,
-				$image_size,
-				false,
-				$image_args
-			);
-		} else {
-			the_post_thumbnail(
-				$image_size,
-				$image_args
-			);
-		}
+		the_post_thumbnail(
+			$image_size,
+			$image_args
+		);
 		?>
 		<div class="post-preview-card__overlay bg-dark bg-opacity-50 w-100 h-100 z-1"></div>
 		<figcaption class="h-auto text-white position-relative z-2 mx-5 mb-3">


### PR DESCRIPTION
removes alignment from mobile sizes. now the image just "is"